### PR TITLE
fix: update Docker build contexts for multi-stage builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,17 @@
 services:
 
   model-service:
-    build: ../model-service
+    build: 
+      context: ..
+      dockerfile: model-service/Dockerfile
     container_name: model-service
     ports:
       - "8081:8081"
 
   app:
-    build: ../app
+    build:
+      context: ..
+      dockerfile: app/Dockerfile
     container_name: app
     ports:
       - "8080:8080"


### PR DESCRIPTION
- Set build context to parent directory (..) for both services
- Enable access to lib-version directory from app service build
- Enable access to model-service directory from model-service build

This resolves the docker compose up --build failures by ensuring proper build context access for multi-stage containerization.