### PR TITLE
fix: Update model environment variables and model-service image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ kubectl label ns default istio-injection=enabled
 ### Step 2: Deploy Application with Monitoring
 ```bash
 # Deploy using Helm chart
-cd charts/project-app
+cd /vagrant/charts/project-app
 helm install project .
 ```
 

--- a/charts/project-app/templates/configmap.yaml
+++ b/charts/project-app/templates/configmap.yaml
@@ -6,6 +6,4 @@ data:
   MODEL_HOST: "http://{{ include "project-app.fullname" . }}-model:8081"
   MODEL_DIR: "{{ .Values.modelService.mountPath }}"
   MODEL_URL: "https://github.com/doda25-team6/model-service/releases/download/v0.1.3/model-v0.1.3.joblib"
-  PREPROCESSOR_URL: ""
-  exampleValue: "{{ .Values.config.exampleValue }}"
-  logLevel: "{{ .Values.config.logLevel }}"
+  PREPROCESSOR_URL: "https://github.com/doda25-team6/model-service/releases/download/v0.1.3/preprocessor-v0.1.3.joblib"

--- a/charts/project-app/templates/configmap.yaml
+++ b/charts/project-app/templates/configmap.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: {{ include "project-app.fullname" . }}-config
 data:
-  model-host: "http://{{ include "project-app.fullname" . }}-model:8081"
+  MODEL_HOST: "http://{{ include "project-app.fullname" . }}-model:8081"
+  MODEL_DIR: "{{ .Values.modelService.mountPath }}"
+  MODEL_URL: "https://github.com/doda25-team6/model-service/releases/download/v0.1.3/model-v0.1.3.joblib"
+  PREPROCESSOR_URL: ""
   exampleValue: "{{ .Values.config.exampleValue }}"
   logLevel: "{{ .Values.config.logLevel }}"

--- a/charts/project-app/templates/deployment.yaml
+++ b/charts/project-app/templates/deployment.yaml
@@ -25,15 +25,11 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: {{ include "project-app.fullname" . }}-config
-                key: model-host
-          - name: LOG_LEVEL
-            value: "{{ .Values.config.logLevel }}"
-          - name: EXAMPLE_VALUE
-            value: "{{ .Values.config.exampleValue }}"
+                key: MODEL_HOST
           - name: EXAMPLE_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ include "project-app.fullname" . }}
+                name: {{ include "project-app.fullname" . }}-secret
                 key: example-secret
 
         volumeMounts:
@@ -76,15 +72,11 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: {{ include "project-app.fullname" . }}-config
-                key: model-host
-          - name: LOG_LEVEL
-            value: "{{ .Values.config.logLevel }}"
-          - name: EXAMPLE_VALUE
-            value: "{{ .Values.config.exampleValue }}"
+                key: MODEL_HOST
           - name: EXAMPLE_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ include "project-app.fullname" . }}
+                name: {{ include "project-app.fullname" . }}-secret
                 key: example-secret
 
         volumeMounts:

--- a/charts/project-app/templates/model-deployment.yaml
+++ b/charts/project-app/templates/model-deployment.yaml
@@ -26,10 +26,23 @@ spec:
         ports:
         - containerPort: {{ .Values.modelService.service.port }}
         env:
+          - name: MODEL_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "project-app.fullname" . }}-config
+                key: MODEL_DIR
+          - name: MODEL_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "project-app.fullname" . }}-config
+                key: MODEL_URL
+          - name: PREPROCESSOR_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "project-app.fullname" . }}-config
+                key: PREPROCESSOR_URL
           - name: SERVER_PORT
             value: "{{ .Values.modelService.service.port }}"
-          - name: MODEL_DIRECTORY
-            value: "{{ .Values.modelService.mountPath }}"
         volumeMounts:
         - name: model-volume
           mountPath: {{ .Values.modelService.mountPath }}
@@ -69,10 +82,23 @@ spec:
         ports:
         - containerPort: {{ .Values.modelService.service.port }}
         env:
+          - name: MODEL_DIR
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "project-app.fullname" . }}-config
+                key: MODEL_DIR
+          - name: MODEL_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "project-app.fullname" . }}-config
+                key: MODEL_URL
+          - name: PREPROCESSOR_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "project-app.fullname" . }}-config
+                key: PREPROCESSOR_URL
           - name: SERVER_PORT
             value: "{{ .Values.modelService.service.port }}"
-          - name: MODEL_DIRECTORY
-            value: "{{ .Values.modelService.mountPath }}"
         volumeMounts:
         - name: model-volume
           mountPath: {{ .Values.modelService.mountPath }}

--- a/charts/project-app/templates/secret.yaml
+++ b/charts/project-app/templates/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "project-app.fullname" . }}
+  name: {{ include "project-app.fullname" . }}-secret
 type: Opaque
 stringData:
   example-secret: "{{ .Values.secretValues.exampleSecret }}"

--- a/charts/project-app/templates/secret.yaml
+++ b/charts/project-app/templates/secret.yaml
@@ -4,4 +4,5 @@ metadata:
   name: {{ include "project-app.fullname" . }}-secret
 type: Opaque
 stringData:
-  example-secret: "{{ .Values.secretValues.exampleSecret }}"
+  example-secret: "test"
+

--- a/charts/project-app/values.yaml
+++ b/charts/project-app/values.yaml
@@ -90,17 +90,17 @@ modelService:
   enabled: true
   image:
     repository: ghcr.io/doda25-team6/model-service
-    tag: "v0.1.5"
+    tag: "v0.1.7"
     pullPolicy: IfNotPresent
   # Canary versions for the model service (Istio subsets v1/v2)
   # When enabled, the chart can run both versions behind the same Service.
   versions:
     v1:
       image:
-        tag: "v0.1.5"
+        tag: "v0.1.7"
     v2:
       image:
-        tag: "v0.1.5"
+        tag: "v0.1.7"
   replicaCount: 3
   mountPath: "/app/output"
   service:

--- a/charts/project-app/values.yaml
+++ b/charts/project-app/values.yaml
@@ -31,13 +31,6 @@ ingress:
   path: "/"
   tls: false
 
-config:
-  exampleValue: "placeholder"
-  logLevel: "info"
-
-secretValues:
-  exampleSecret: "to-replace"
-
 # Persistent storage configuration
 persistence:
   enabled: true
@@ -97,17 +90,17 @@ modelService:
   enabled: true
   image:
     repository: ghcr.io/doda25-team6/model-service
-    tag: "v0.1.3"
+    tag: "v0.1.5"
     pullPolicy: IfNotPresent
   # Canary versions for the model service (Istio subsets v1/v2)
   # When enabled, the chart can run both versions behind the same Service.
   versions:
     v1:
       image:
-        tag: "v0.1.3"
+        tag: "v0.1.5"
     v2:
       image:
-        tag: "v0.1.3"
+        tag: "v0.1.5"
   replicaCount: 3
   mountPath: "/app/output"
   service:

--- a/charts/project-app/values.yaml
+++ b/charts/project-app/values.yaml
@@ -90,17 +90,17 @@ modelService:
   enabled: true
   image:
     repository: ghcr.io/doda25-team6/model-service
-    tag: "v0.1.7"
+    tag: "v0.1.9"
     pullPolicy: IfNotPresent
   # Canary versions for the model service (Istio subsets v1/v2)
   # When enabled, the chart can run both versions behind the same Service.
   versions:
     v1:
       image:
-        tag: "v0.1.7"
+        tag: "v0.1.9"
     v2:
       image:
-        tag: "v0.1.7"
+        tag: "v0.1.9"
   replicaCount: 3
   mountPath: "/app/output"
   service:


### PR DESCRIPTION
Recent fixes in the model-service repo required updates to the environment variables and model-service image tag.

The added environment variables were added to the existing ConfigMap, which is accessed in the model deployment resources. I have read that this is better practice than putting all environment variables in values.yaml, since any update to values.yaml restarts the pods through Helm. Therefore, I have removed the portions for 'config' and 'secret' (secrets should only be in the K8s resources) from values.yaml.

After https://github.com/doda25-team6/model-service/pull/14 is merged and an image tag (v0.1.5) is pushed, this PR can be merged as well.