### PR TITLE
Fix: provide URLs for downloading model files when using Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,11 @@ APP_HOST_PORT=8080
 SERVER_PORT=8081
 MODEL_HOST=http://model-service:8081
 
+MODEL_URL: "https://github.com/doda25-team6/model-service/releases/download/v0.1.3/model-v0.1.3.joblib"
+PREPROCESSOR_URL: "https://github.com/doda25-team6/model-service/releases/download/v0.1.3/preprocessor-v0.1.3.joblib"
+
+APP_IMAGE: "ghcr.io/doda25-team6/app:0.0.98"
+MODEL_IMAGE: "ghcr.io/doda25-team6/model-service:v0.2.0"
+
 # Optional: Model service configuration
-# MODEL_RELEASE_TAG=v0.1.2
+# MODEL_RELEASE_TAG=v0.1.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     environment:
       SERVER_PORT: "${SERVER_PORT:-8081}"
       MODEL_DIR: /app/output
-      MODEL_URL: "file:///app/output/model.joblib"
-      PREPROCESSOR_URL: "file:///app/output/preprocessor.joblib"
+      MODEL_URL: "https://github.com/doda25-team6/model-service/releases/download/v0.1.3/model-v0.1.3.joblib"
+      PREPROCESSOR_URL: "https://github.com/doda25-team6/model-service/releases/download/v0.1.3/preprocessor-v0.1.3.joblib"
 
     # Without this, the model-service would always download 
     # since output would be empty.


### PR DESCRIPTION
When the model files are not already stored locally, they need to be downloaded from the GitHub release page. The previous local URLs caused errors during the download attempt.